### PR TITLE
Node Duplicate Command Error fix

### DIFF
--- a/.ebextensions/nodecommand.config
+++ b/.ebextensions/nodecommand.config
@@ -1,4 +1,0 @@
-option_settings:
-  - namespace: aws:elasticbeanstalk:container:nodejs
-    option_name: NodeCommand
-    value: "npm start"

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start


### PR DESCRIPTION
After deploying the `.ebextensions` approach ... received an error in the `Code Pipeline` where the Deploy stage did not complete. The error logged was 

```javascript
Action execution failed 
Deployment completed, but with errors: Failed to deploy application. Unknown or duplicate parameter: NodeCommand "option_settings" in one of the configuration files failed validation. More details to follow.
```

With this error, followed StackOverflow to this suggestion [Unkown or duplicate parameter: NodeCommand](https://stackoverflow.com/questions/61782952/unknown-or-duplicate-parameter-nodecommand). 

- [ ] Implemented a `Procfile` with suggested configuration. 
